### PR TITLE
Issue #4: Fix resizing of htmlwidgets in mini.html view

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -202,12 +202,18 @@ as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
   )
 
   if (ocaps) htmlwidgets.install.ocap()
-
+  
+  where <- paste0("rc_htmlwidget_content_", as.integer(runif(1)*1e6))
+  
   paste(
     sep = "",
+    "<div class=\"rcloud-htmlwidget-content\" id=\"",
+    where,
+    "\">",
     "<iframe frameBorder=\"0\" width=\"100%\" height=\"400\" srcdoc=\"",
     gsub("\"", "&quot;", paste(html, collapse = "\n")),
-    "\"></iframe>"
+    "\"></iframe>",
+    "</div>"
   )
 }
 

--- a/inst/javascript/htmlwidgets.js
+++ b/inst/javascript/htmlwidgets.js
@@ -47,7 +47,7 @@ function size_this(div, reset) {
 }
 
 function resize_all(reset) {
-    var widgets = $('.rcloud-htmlwidget').find('div');
+    var widgets = $('.rcloud-htmlwidget-content');
     $.map(
         widgets,
         function(w) {


### PR DESCRIPTION
The problem here was that the 'rcloud-htmlwidget' wrapper div of the iframe holding the widget content only existed in IDE mode. 

I modified the as.character.htmlwidget function (invoked by both IDE and mini) so it returns iframe wrapped in a div which then can be used in JS to discover the iframe.