### PR TITLE
Initial version of integration with trelliscopejs

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,8 +1,13 @@
 
 importFrom("utils", "packageName")
+importFrom("trelliscopejs", "trelliscope")
 export(print.htmlwidget)
 export(print.suppress_viewer)
 export(print.shiny.tag)
+export(print.facet_trelliscope)
+export(trelliscope.data.frame)
+S3method(print,facet_trelliscope)
+S3method(trelliscope,data.frame)
 S3method(print, shiny.tag)
 S3method(as.character, shiny.tag)
 S3method(print, htmlwidget)

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -250,6 +250,24 @@ print.suppress_viewer <- print.htmlwidget
 
 print.shiny.tag <- print.htmlwidget
 
+print.facet_trelliscope <- function(x, ..., view = interactive()) {
+  attrs <- attr(x, "trelliscope")
+  attrs$self_contained = TRUE
+  attr(x, "trelliscope") <- attrs
+  
+  invisible(trelliscopejs:::print.facet_trelliscope(x))
+}
+
+trelliscope.data.frame <- function(x, name, group = "common", desc = "",
+                                   md_desc = "", path = NULL, height = 500, width = 500, auto_cog = TRUE, state = NULL,
+                                   nrow = 1, ncol = 1, jsonp = TRUE, self_contained = TRUE, thumb = TRUE) {
+  trelliscopejs:::trelliscope.data.frame(x, name, group = group, desc = desc, md_desc = md_desc, path = path, 
+                                                   height = height, width = width, auto_cog = auto_cog, state = state, 
+                                                   nrow = nrow, ncol = ncol, jsonp = jsonp, self_contained = self_contained, 
+                                                   thumb = thumb)
+}
+
+
 rcloudHTMLDependency <- function(dep) {
 
   file <- dep$src$file


### PR DESCRIPTION
Trelliscope functions when ran from rcloud need to have the self_contained parameter set to true,
e.g.:

```
library(ggplot2)
library(gapminder)
indata<-gapminder[which(gapminder$country %in% c('Spain', 'Portugal')),]
qplot(year, lifeExp, data = indata) +
  xlim(1950, 2011) + ylim(50, 95) + theme_bw() +
  facet_trelliscope(~ country + continent, nrow = 2, ncol = 7, width = 300, self_contained = TRUE
         )
```

When this parameter is not set then the output is written to a file and a new tab is opened pointing to a file in 'tmp' directory (which is unreachable of course).

Here I tried to make sure that the self_contained parameter is automatically set so that the trelliscope dashboard is displayed in the notebook cell. This way even if users forget to set the self_contained parameter it will be set for them (and will prevent the new tab from being displayed).

This works in edit.html and view.html but it doesn't in flexdashboard. This is because flexdashboard doesn't use rcloud.htmlwidgets and if the self_contained parameter is not set to TRUE the page fails to generate. 
(Ensuring that the parameter has required value in flexdashboard would require overriding the methods within context that knitr is running)

The solution here isn't great as rcloud.htmlwidgets has a dependency on trelliscopejs package now as well. This is because rcloud.htmlwidgets has to override the 'trelliscope' method which is defined in there...

@gordonwoodhull  please let me know what are your thoughts.


