### PR TITLE
Fix #14 by adding support for js dependencies residing in 'lib' directories

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -273,7 +273,7 @@ rcloudHTMLDependency <- function(dep) {
   } else if (c_rel_path[2] == "htmlwidgets") {
     dep$src$href <- paste0("/shared.R/_htmlwidgets/", pkg, "/", pkgpath)
 
-  } else if (c_rel_path[2] == "www") {
+  } else if (c_rel_path[2] %in% c("www", "lib")) {
     dep$src$href <- paste0("/shared.R/", pkg, "/", pkgpath)
   }
 


### PR DESCRIPTION
plotly widgets reference JavaScript libraries from 'crosstalk' package which are stored in its 'lib' directory. Because rcloud.htmlwidgets was assuming that the dependencies can only reside in 'www' directories, jquery couldn't be found.

I simply made 'lib' directory one of the possible dependency sources.