### PR TITLE
 Use function_call result to update htmlwidget div.

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -259,7 +259,7 @@ print.htmlwidget <- function(x, ..., view = interactive()) {
 
   ocaps <- htmlwidgets.install.ocap()
 
-  ocaps$create(where, widget)
+  ocaps$create(Rserve.context(), where, widget)
 
   invisible(x)
 }

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -259,7 +259,7 @@ print.htmlwidget <- function(x, ..., view = interactive()) {
 
   ocaps <- htmlwidgets.install.ocap()
 
-  ocaps$create(Rserve.context(), where, widget)
+  ocaps$create(where, widget)
 
   invisible(x)
 }

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -206,8 +206,9 @@ as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
 #'  this implementation.
 #' 
 as.character.shiny.tag <- function(x, ocaps = TRUE, rcloud_htmlwidgets_print = FALSE,  ...) {
-  if(!rcloud_htmlwidgets_print) {
-     .htmltools.as.character.shiny.tag(x, ...)
+  if( ! rcloud_htmlwidgets_print || 
+     (('attribs' %in% names(x)) && 'data-rcloud-htmlwidgets-compact' %in% names(x$attribs))) {
+    .htmltools.as.character.shiny.tag(x, ...)
   } else {
     rendered <- htmltools::renderTags(x)
     deps <- lapply(rendered$dependencies, rcloudHTMLDependency)
@@ -258,14 +259,20 @@ print.htmlwidget <- function(x, ..., view = interactive()) {
 
   ocaps <- htmlwidgets.install.ocap()
 
-  ocaps$create(where, widget)
+  ocaps$create(Rserve.context(), where, widget)
 
   invisible(x)
 }
 
 print.suppress_viewer <- print.htmlwidget
 
-print.shiny.tag <- print.htmlwidget
+print.shiny.tag <- function(x, ..., view = interactive()) {
+  if('attribs' %in% names(x) && 'data-rcloud-htmlwidgets-compact' %in% names(x$attribs)) {
+    rcloud.html.out(as.character.shiny.tag(x, ...))
+  } else {
+    invisible(print.htmlwidget(x, ..., view = view))
+  }
+}
 
 ## this is a hack for R 3.5.0+ which prevents us from
 ## overriding methods in htmlwidgets/htmltools
@@ -280,7 +287,7 @@ print.shiny.tag <- print.htmlwidget
     }
   }
   .doit("htmlwidgets", c("print.suppress_viewer", "print.htmlwidget"))
-  .doit("htmltools", "as.character.shiny.tag")
+  .doit("htmltools", c("as.character.shiny.tag", "print.shiny.tag"))
   TRUE
 }
 


### PR DESCRIPTION
This fixes the race condition between rcloud.htmlwidgets and cell results processing queue.

>  Please note that just the last commit is relevant for this review, as this branch is based on att/rcloud.htmlwidgets/pull/25 