### PR TITLE
detect user libraries and add to shared.R path if needed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcloud.htmlwidgets
 Title: Html Widgets in RCloud
-Version: 1.1.0
+Version: 1.1.1
 Author: Gábor Csárdi <gcsardi@mango-solutions.com>
 Maintainer: Gordon Woodhull <gordon@research.att.com>
 Description: Embed HTML widgets in RCloud notebooks. This is a support

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
+## 1.1.1
+* merges user library support from 1.0.8
+
 ## 1.1.0
 * more efficient embedding in RCloud cells
 * support for displaying without iframe
+
+## 1.0.8
+* detect user library paths and produce corresponding `shared.R` URLs
 
 ## 1.0.7
 * call resolveDependencies in order to remove redundant dependencies. (DT was broken because of multiple jQuery)

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -313,17 +313,30 @@ rcloudHTMLDependency <- function(dep) {
     ## strip off pkg/www or pkg/htmlwidgets
     pkgpath <- paste(tail(c_rel_path, -2), collapse = "/")
 
+    user <- is_user_lib(lib)
+    parts <- NULL
     if (length(c_rel_path) < 2) {
       warning("Invalid htmlwidgets dependency path: ", file)
       return(dep)
     } else if (c_rel_path[2] == "htmlwidgets") {
-      dep$src$href <- paste0("/shared.R/_htmlwidgets/", pkg, "/", pkgpath)
+      parts <- c('/shared.R', '_htmlwidgets')
+      if(!is.null(user)) parts = c(parts, user)
+      parts <- c(parts, pkg, pkgpath)
     } else if (c_rel_path[2] %in% c("www", "lib")) {
-      dep$src$href <- paste0("/shared.R/", pkg, "/", pkgpath)
+      parts <- c('/shared.R')
+      if(!is.null(user)) parts = c(parts, user)
+      parts <- c(parts, pkg, pkgpath)
     }
+    if(!is.null(parts))
+      dep$src$href <- paste0(parts, collapse='/')
   }
 
   dep
+}
+
+is_user_lib <- function(path) {
+    found <- gsub(rcloud.home('library', user='([a-z_][a-z0-9_]*)'), '\\1', path) 
+    if(found == path) NULL else found
 }
 
 where_in_path <- function(path, parents) {

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -348,7 +348,7 @@ rcloudHTMLDependency <- function(dep) {
 }
 
 is_user_lib <- function(path) {
-    found <- gsub(rcloud.home('library', user='([^/]*)'), '\\1', path) 
+    found <- gsub(rcloud.home('library.*', user='([^/]*)'), '\\1', path)
     if(found == path) NULL else found
 }
 


### PR DESCRIPTION
@s-u, please review. I tested the code in a notebook but I need a multiuser setup in order to test it in reality.

My summary of our earlier conversation is here:
https://github.com/att/rcloud.htmlwidgets/pull/17#issuecomment-308551464

Unfortunately we can't use `getNamespaceInfo` here because most of the time we'll be given the complete path and need to determine the package from it. That's why this code compares path prefixes across `.libPaths()` instead.